### PR TITLE
Enable async execution of the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.2.0 -- UNRELEASED
+
 ## 0.1.1 -- 19 Apr 2017
 
 Update dependency on Lacinia to latest, 0.15.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 0.2.0 -- UNRELEASED
 
+Updated to Lacinia 0.16.0.
+
+Added an option to execute the GraphQL request asynchronously; when enabled,
+the handler returns a channel that conveys the Pedestal context containing
+the response, once the query has finished executing.
+
+Introduced function `com.walmartlabs.lacinia.pedestal/inject-app-context-interceptor` and
+converted `query-executor-handler` from a function to constant.
+
 ## 0.1.1 -- 19 Apr 2017
 
 Update dependency on Lacinia to latest, 0.15.0.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The steps for processing a GraphQL query are broken into multiple stages:
 - Extracting the query string and query variables from the request
 - Verifying that a query was included in the request
 - Converting the query string to a parsed query
-- Executing the parsed query
+- Defining the application context for executing the query
+- Executing the parsed query (possibly, asynchronously)
 - Setting the response status
 - Encoding the response body as JSON
 

--- a/dev-resources/com/walmartlabs/lacinia/test_utils.clj
+++ b/dev-resources/com/walmartlabs/lacinia/test_utils.clj
@@ -1,0 +1,70 @@
+(ns com.walmartlabs.lacinia.test-utils
+  (:require [clj-http.client :as client]
+            [io.pedestal.http :as http]
+            [com.walmartlabs.lacinia.pedestal :as lp]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [com.walmartlabs.lacinia.util :as util]
+            [com.walmartlabs.lacinia.schema :as schema]
+            [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
+            [cheshire.core :as cheshire]))
+
+(defn ^:private resolve-echo
+  [context args _]
+  (let [{:keys [value error]} args
+        error-map (when error
+                    {:message "Forced error."
+                     :status error})
+        resolved-value {:value value
+                        :method (get-in context [:request :request-method])}]
+    (resolve-as resolved-value error-map)))
+
+(defn sample-schema-fixture
+  [options]
+  (fn [f]
+    (let [schema (-> (io/resource "sample-schema.edn")
+                     slurp
+                     edn/read-string
+                     (util/attach-resolvers {:resolve-echo resolve-echo})
+                     schema/compile)
+          service (lp/pedestal-service schema options)]
+      (http/start service)
+      (try
+        (f)
+        (finally
+          (http/stop service))))))
+
+
+(defn get-url
+  [path]
+  (client/get (str "http://localhost:8888" path) {:throw-exceptions false}))
+
+(defn send-request
+  "Sends a GraphQL request to the server and returns the response."
+  ([query]
+   (send-request :get query))
+  ([method query]
+   (send-request method query nil))
+  ([method query vars]
+   (-> {:method method
+        :url "http://localhost:8888/graphql"
+        :throw-exceptions false}
+       (cond->
+         (= method :get)
+         (assoc-in [:query-params :query] query)
+
+         (= method :post)
+         (assoc-in [:headers "Content-Type"] "application/graphql")
+
+         ;; :post-bad is like :post, but without setting the content type
+         (#{:post :post-bad} method)
+         (assoc :body query
+                :method :post)
+
+         vars
+         (assoc-in [:query-params :variables] (cheshire/generate-string vars)))
+       client/request
+       (update :body #(try
+                        (cheshire/parse-string % true)
+                        (catch Exception t
+                          %))))))

--- a/dev-resources/logback.xml
+++ b/dev-resources/logback.xml
@@ -10,4 +10,8 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
+
+    <!-- Switch to DEBUG to see each interceptor execute: -->
+    <logger name="io.pedestal.interceptor" level="warn"/>
+
 </configuration>

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject com.walmartlabs/pedestal-lacinia "0.1.1"
+(defproject com.walmartlabs/pedestal-lacinia "0.2.0"
   :description "Pedestal infrastructure supporting Lacinia GraphQL"
   :url "https://github.com/walmartlabs/pedestal-lacinia"
   :license {:name "Apache Software License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.walmartlabs/lacinia "0.15.0"]
+                 [com.walmartlabs/lacinia "0.16.0"]
                  [com.fasterxml.jackson.core/jackson-core "2.5.3"]
                  [io.pedestal/pedestal.service "0.5.2"]
                  [io.pedestal/pedestal.jetty "0.5.2"]]

--- a/src/com/walmartlabs/lacinia/pedestal.clj
+++ b/src/com/walmartlabs/lacinia/pedestal.clj
@@ -1,15 +1,16 @@
 (ns com.walmartlabs.lacinia.pedestal
   "Defines Pedestal interceptors and supporting code."
   (:require
+    [clojure.core.async :refer [chan put!]]
     [com.walmartlabs.lacinia :as lacinia]
     [com.walmartlabs.lacinia.parser :refer [parse-query]]
     [cheshire.core :as cheshire]
     [io.pedestal.interceptor :refer [interceptor]]
     [clojure.string :as str]
-    [clojure.java.io :as io]
     [io.pedestal.http :as http]
     [io.pedestal.http.route :as route]
-    [ring.util.response :as response]))
+    [ring.util.response :as response]
+    [com.walmartlabs.lacinia.resolve :as resolve]))
 
 (defn bad-request
   "Generates a bad request Ring response."
@@ -139,35 +140,68 @@
                                   (map #(dissoc % :status) errors))))
                   context)))}))
 
-(defn query-executor-handler
+(defn inject-app-context-interceptor
+  "Adds a :lacinia-app-context key to the request, used when executing the query.
+
+  The provided app-context map is augmented with the request map, as key :request."
+  {:added "0.2.0"}
+  [app-context]
+  (interceptor
+    {:name ::inject-app-context
+     :enter (fn [context]
+              (assoc-in context [:request :lacinia-app-context]
+                        (assoc app-context :request (:request context))))}))
+
+(defn ^:private apply-result-to-context
+  [context result]
+  ;; When :data is missing, then a failure occured during parsing or preparing
+  ;; the request, which indicates a bad request, rather than some failure
+  ;; during execution.
+  (let [status (if (contains? result :data)
+                 200
+                 400)
+        response {:status status
+                  :headers {}
+                  :body result}]
+    (assoc context :response response)))
+
+(def query-executor-handler
   "The handler at the end of interceptor chain, invokes Lacinia to
   execute the query and return the main response.
 
   The handler adds the Ring request map as the :request key to the provided
   app-context before executing the query.
 
-  This comes after [[query-parser-interceptor]]
+  This comes after [[query-parser-interceptor]], [[inject-app-context-interceptor]],
   and [[status-conversion-interceptor]] in the interceptor chain."
-  [app-context]
   (interceptor
     {:name ::query-executor
      :enter (fn [context]
               (let [request (:request context)
                     {q :parsed-lacinia-query
-                     vars :graphql-vars} request
-                    result (lacinia/execute-parsed-query q
-                                                         vars
-                                                         (assoc app-context :request request))
-                    ;; When :data is missing, then a failure occured during parsing or preparing
-                    ;; the request, which indicates a bad request, rather than some failure
-                    ;; during execution.
-                    status (if (contains? result :data)
-                             200
-                             400)
-                    response {:status status
-                              :headers {}
-                              :body result}]
-                (assoc context :response response)))}))
+                     vars :graphql-vars
+                     app-context :lacinia-app-context} request
+                    result (lacinia/execute-parsed-query q vars app-context)]
+                (apply-result-to-context context result)))}))
+
+(def ^ {:added "0.2.0"} async-query-executor-handler
+  "Async variant of [[query-executor-handler]] which returns a channel that conveys the
+  updated context."
+  (interceptor
+    {:name ::async-query-executor
+     :enter (fn [context]
+              (let [request (:request context)
+                    {q :parsed-lacinia-query
+                     vars :graphql-vars
+                     app-context :lacinia-app-context} request
+                    ch (chan 1)
+                    resolver-result (lacinia/execute-parsed-query-async q vars app-context)]
+                (resolve/on-deliver! resolver-result
+                                     (fn [result _]
+                                       (->> result
+                                            (apply-result-to-context context)
+                                            (put! ch))))
+                ch))}))
 
 (defn graphql-routes
   "Creates default routes for handling GET and POST requests (at `/graphql`) and
@@ -184,12 +218,16 @@
   * [[missing-query-interceptor]]
   * [[query-parser-interceptor]]
   * [[status-conversion-interceptor]]
-  * [[query-executor-handler]]
+  * [[inject-app-context-interceptor]]
+  * [[query-executor-handler]] or [[async-query-executor-handler]]
 
   Options:
 
   :graphiql (default false)
   : If true, enables routes for the GraphiQL IDE.
+
+  :async (default false)
+  : If true, the query will execute asynchronously.
 
   :app-context
   : The base application context provided to Lacinia when executing a query."
@@ -198,7 +236,10 @@
                         (fn [request]
                           (response/redirect "/index.html")))
         query-parser (query-parser-interceptor compiled-schema)
-        executor (query-executor-handler (:app-context options))]
+        inject-app-context (inject-app-context-interceptor (:app-context options))
+        executor (if (:async options)
+                   async-query-executor-handler
+                   query-executor-handler)]
     (cond-> #{["/graphql" :post
                [json-response-interceptor
                 require-graphql-content-interceptor
@@ -206,6 +247,7 @@
                 missing-query-interceptor
                 query-parser
                 status-conversion-interceptor
+                inject-app-context
                 executor]
                :route-name ::graphql-post]
               ["/graphql" :get
@@ -214,6 +256,7 @@
                 missing-query-interceptor
                 query-parser
                 status-conversion-interceptor
+                inject-app-context
                 executor]
                :route-name ::graphql-get]}
       index-handler (conj ["/" :get index-handler :route-name ::graphiql-ide-index]))))

--- a/test/com/walmartlabs/lacinia/async_test.clj
+++ b/test/com/walmartlabs/lacinia/async_test.clj
@@ -1,0 +1,25 @@
+(ns com.walmartlabs.lacinia.async-test
+  (:require
+    [clojure.test :refer [deftest is use-fixtures]]
+    [com.walmartlabs.lacinia.test-utils :refer [sample-schema-fixture
+                                                send-request]]))
+
+;; TODO: Some way to verify that processing is actually async.
+
+(use-fixtures :once (sample-schema-fixture {:async true}))
+
+(deftest async-get
+  (let [response (send-request "{ echo(value: \"hello\") { value method }}")]
+    (is (= 200 (:status response)))
+    (is (= "application/json"
+           (get-in response [:headers "Content-Type"])))
+    (is (= {:data {:echo {:method "get"
+                          :value "hello"}}}
+           (:body response)))))
+
+(deftest async-post
+  (let [response (send-request :post "{ echo(value: \"hello\") { value method }}")]
+    (is (= 200 (:status response)))
+    (is (= {:data {:echo {:method "post"
+                          :value "hello"}}}
+           (:body response)))))

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -1,74 +1,13 @@
 (ns com.walmartlabs.lacinia.pedestal-test
   (:require
     [clojure.test :refer [deftest is use-fixtures]]
-    [clojure.java.io :as io]
-    [com.walmartlabs.lacinia.util :as util]
-    [com.walmartlabs.lacinia.schema :as schema]
-    [com.walmartlabs.lacinia.resolve :refer [resolve-as]]
     [com.walmartlabs.lacinia.pedestal :as lp]
-    [io.pedestal.http :as http]
     [clj-http.client :as client]
-    [cheshire.core :as cheshire]
-    [clojure.edn :as edn]
-    [clojure.string :as str]))
+    [clojure.string :as str]
+    [com.walmartlabs.lacinia.test-utils :refer [sample-schema-fixture
+                                                send-request]]))
 
-(defn ^:private resolve-echo
-  [context args _]
-  (let [{:keys [value error]} args
-        error-map (when error
-                    {:message "Forced error."
-                     :status error})
-        resolved-value {:value value
-                        :method (get-in context [:request :request-method])}]
-    (resolve-as resolved-value error-map)))
-
-(use-fixtures :once
-  (fn [f]
-    (let [schema (-> (io/resource "sample-schema.edn")
-                     slurp
-                     edn/read-string
-                     (util/attach-resolvers {:resolve-echo resolve-echo})
-                     schema/compile)
-          service (lp/pedestal-service schema {:graphiql true})]
-      (http/start service)
-      (try
-        (f)
-        (finally
-          (http/stop service))))))
-
-(defn ^:private get-url
-  [path]
-  (client/get (str "http://localhost:8888" path) {:throw-exceptions false}))
-
-(defn ^:private send-request
-  "Sends a GraphQL request to the server and returns the response."
-  ([query]
-   (send-request :get query))
-  ([method query]
-   (send-request method query nil))
-  ([method query vars]
-   (-> {:method method
-        :url "http://localhost:8888/graphql"
-        :throw-exceptions false}
-       (cond->
-         (= method :get)
-         (assoc-in [:query-params :query] query)
-
-         (= method :post)
-         (assoc-in [:headers "Content-Type"] "application/graphql")
-
-         ;; :post-bad is like :post, but without setting the content type
-         (#{:post :post-bad} method)
-         (assoc :body query
-                :method :post)
-
-         vars
-         (assoc-in [:query-params :variables] (cheshire/generate-string vars)))
-       client/request
-       (update :body #(try
-                        (cheshire/parse-string % true)
-                        (catch Exception t
-                          %))))))
+(use-fixtures :once (sample-schema-fixture {:graphiql true}))
 
 (deftest simple-get-query
   (let [response (send-request "{ echo(value: \"hello\") { value method }}")]

--- a/test/com/walmartlabs/lacinia/pedestal_test.clj
+++ b/test/com/walmartlabs/lacinia/pedestal_test.clj
@@ -95,7 +95,7 @@
 (deftest status-set-by-error
   (let [response (send-request "{ echo(value: \"Baked.\", error: 420) { value }}")]
     (is (= {:body {:data {:echo {:value "Baked."}}
-                   :errors [{:arguments {:error 420
+                   :errors [{:arguments {:error "420"
                                          :value "Baked."}
                              :locations [{:column 0
                                           :line 1}]


### PR DESCRIPTION
Adds support for executing the query asynchronously.

In addition, this adds a new interceptor for setting the application context when executing the query; this makes it easier to customize that behavior while still using the default query executor handler.